### PR TITLE
Date Prop Format Error Fix

### DIFF
--- a/client/src/util/entry.ts
+++ b/client/src/util/entry.ts
@@ -131,7 +131,7 @@ export function parsedPropsToRawProps(
                         );
                     } else if (
                         typeof valueItem.timestamp !== 'number' ||
-                        typeof valueItem.timezoneOffet !== 'number'
+                        typeof valueItem.timezoneOffset !== 'number'
                     ) {
                         throw Error(
                             `[${level}.${propSchema.name}.${j}] item value "${JSON.stringify(valueItem)}" is not allowed. It must be formated: {timestamp: number, timezoneOffset: number}`,
@@ -149,7 +149,7 @@ export function parsedPropsToRawProps(
             }
             if (
                 typeof metaValue.timestamp !== 'number' ||
-                typeof metaValue.timezoneOffet !== 'number'
+                typeof metaValue.timezoneOffset !== 'number'
             ) {
                 throw Error(
                     `[${level}.${propSchema.name}] value "${JSON.stringify(metaValue)}" is not allowed. It must be formated: {timestamp: number, timezoneOffset: number}`,


### PR DESCRIPTION
If I `CREATE` or `UPDATE` an entry using `bcms.create()` or `bcms.update()` when there is a `DATE` prop in the template, it gives an error message saying:

```
[entry.due_date] value "{"timestamp":1743191940000,"timezoneOffset":300}" is not allowed. It must be formatted: {timestamp: number, timezoneOffset: number}
```

This error is due to "timezoneOffset" being misspelled as "timezoneOffet" at two places in the entry file, at the places where it checks if both `timestamp` and `timezoneOffset` are of the type `number`.

This pull request fixes the typographical errors.